### PR TITLE
Complete CenterState Logic for Drone Navigation to the Map Center

### DIFF
--- a/src/main/java/ca/mcmaster/se2aa4/island/teamXXX/algorithm/spiral/CenterState.java
+++ b/src/main/java/ca/mcmaster/se2aa4/island/teamXXX/algorithm/spiral/CenterState.java
@@ -17,8 +17,8 @@ public class CenterState extends State {
     }
 
     public boolean isCenter(Position position){
-        int centerX = mapWidth / 2;
-        int centerY = mapHeight / 2;
+        int centerX = (int) Math.ceil(mapWidth / 2);
+        int centerY = (int) Math.ceil(mapHeight / 2);
         boolean is_center = (position.getX()== centerX && position.getY() == centerY);
         return is_center;
 

--- a/src/main/java/ca/mcmaster/se2aa4/island/teamXXX/algorithm/spiral/CenterState.java
+++ b/src/main/java/ca/mcmaster/se2aa4/island/teamXXX/algorithm/spiral/CenterState.java
@@ -3,12 +3,25 @@ package ca.mcmaster.se2aa4.island.teamXXX.algorithm.spiral;
 import ca.mcmaster.se2aa4.island.teamXXX.actions.Action;
 import ca.mcmaster.se2aa4.island.teamXXX.algorithm.State;
 import ca.mcmaster.se2aa4.island.teamXXX.drone.Drone;
+import ca.mcmaster.se2aa4.island.teamXXX.drone.Position;
 import ca.mcmaster.se2aa4.island.teamXXX.result.ActionResult;
 
 public class CenterState extends State {
+    private int mapWidth;
+    private int mapHeight;
 
-    public CenterState(Drone drone) {
+    public CenterState(Drone drone,int mapHeight,int mapWidth) {//Assume DimensionFindingState can transfer width and height as parameter
         super(drone);
+        this.mapHeight = mapHeight;
+        this.mapWidth = mapWidth;
+    }
+
+    public boolean isCenter(Position position){
+        int centerX = mapWidth / 2;
+        int centerY = mapHeight / 2;
+        boolean is_center = (position.getX()== centerX && position.getY() == centerY);
+        return is_center;
+
     }
 
     @Override
@@ -16,8 +29,15 @@ public class CenterState extends State {
         // If the state still has work to be done then it should go to the current state
         // Otherwise it should go to the SpiralState
         // TODO Auto-generated method stub
-        throw new UnsupportedOperationException("Unimplemented method 'nextState'");
+        //throw new UnsupportedOperationException("Unimplemented method 'nextState'");
+
+        if (isCenter(getDrone().getPosition())) {
+            return new SpiralState(getDrone());
+        }
+
+        return this;//if not center, stay at current state
     }
+
 
     @Override
     public Action getAction() {

--- a/src/main/java/ca/mcmaster/se2aa4/island/teamXXX/algorithm/spiral/CenterState.java
+++ b/src/main/java/ca/mcmaster/se2aa4/island/teamXXX/algorithm/spiral/CenterState.java
@@ -29,7 +29,6 @@ public class CenterState extends State {
     @Override
     public State nextState(ActionResult result) {
         Drone drone = getDrone();
-        drone.expend(result.getCost());
         action.consume(drone, result);
         return isCenter() ? new SpiralState(getDrone()) : this;
     }

--- a/src/main/java/ca/mcmaster/se2aa4/island/teamXXX/algorithm/spiral/CenterState.java
+++ b/src/main/java/ca/mcmaster/se2aa4/island/teamXXX/algorithm/spiral/CenterState.java
@@ -7,8 +7,8 @@ import ca.mcmaster.se2aa4.island.teamXXX.drone.Drone;
 import ca.mcmaster.se2aa4.island.teamXXX.result.ActionResult;
 
 public class CenterState extends State {
-    private final int centerX;
-    private final int centerY;
+    private int centerX;
+    private int centerY;
     private Action action;
 
     public CenterState(Drone drone, int mapHeight, int mapWidth) {
@@ -23,7 +23,7 @@ public class CenterState extends State {
         int deltaX = centerX - currentX;
         int deltaY = centerY - currentY;
 
-        return Math.abs(deltaX) <= 1 && Math.abs(deltaY) <= 1;
+        return Math.abs(deltaX) <= 2 && Math.abs(deltaY) <= 2;
     }
 
     @Override
@@ -45,16 +45,106 @@ public class CenterState extends State {
         
         Direction currentDirection = drone.getDirection();
 
-        if (isCenter()) {
-            return null; 
+        if(Math.abs(deltaX)>2 && Math.abs(deltaY)>2){
+            if(deltaX>0 &&deltaY>0){{//drone is at the lower leftcorner 
+                if (currentDirection ==Direction.NORTH ||currentDirection ==Direction.WEST){
+                    action = drone.head(currentDirection.right());
+                }
+                else if (currentDirection ==Direction.SOUTH||currentDirection ==Direction.EAST){
+                    action = drone.head(currentDirection.left());
+
+
+            }
+            else if (deltaX<0 && deltaY>0)//drone is at the lower right corener
+                if (currentDirection ==Direction.SOUTH ||currentDirection ==Direction.WEST){
+                    action = drone.head(currentDirection.right());
+                }
+                else if (currentDirection ==Direction.NORTH||currentDirection ==Direction.EAST){
+                    action = drone.head(currentDirection.left());
+
+            }
+
+            else if  (deltaX>0 && deltaY<0){//drone is at the lower right corner 
+                if (currentDirection ==Direction.EAST ||currentDirection ==Direction.NORTH){
+                    action = drone.head(currentDirection.right());
+                }
+                else if (currentDirection ==Direction.SOUTH ||currentDirection ==Direction.WEST){
+                    action = drone.head(currentDirection.left());
+                }
+
+            }
+
+            else{//drone is at the upper right corner
+                if (currentDirection ==Direction.SOUTH ||currentDirection ==Direction.EAST){
+                    action = drone.head(currentDirection.right());
+                }
+                else if (currentDirection ==Direction.NORTH ||currentDirection ==Direction.WEST){
+                    action = drone.head(currentDirection.left());
+
+            }
+
         }
+        if(deltaX<=2){
+            if (deltaY>0){//drone is south to center
+               if (currentDirection == Direction.NORTH){
+                action = drone.fly();
+               }
+               else {//The direction must be WEST or EAST
+                    if (currentDirection == Direction.EAST){
+                        action = drone.head(currentDirection.left());
+                    }
+                    else {
+                        action = drone.head(currentDirection.right())
+                    }
+                }
+              
+            }
+            else{//drone is NORTH to the center
+                if (currentDirection == Direction.SOUTH){
+                action = drone.fly();
+               }
+               else {//The direction must be WEST or EAST
+                    if (currentDirection == Direction.EAST){
+                        action = drone.head(currentDirection.right());
+                    }
+                    else {
+                        action = drone.head(currentDirection.left())
+                    }
+                }
 
+            }
+        
 
+        }
+        else if (deltaY<=2){
+            if (deltaX>0){//drone is WEST to center
+               if (currentDirection == Direction.EAST){
+                action = drone.fly();
+               }
+               else {//The direction must be NORTH or SOUTH
+                    if (currentDirection == Direction.SOUTH){
+                        action = drone.head(currentDirection.left());
+                    }
+                    else {
+                        action = drone.head(currentDirection.right())
+                    }
+                }
+              
+            }
+            else{//drone is EAST to the center
+                if (currentDirection == Direction.NORTH){
+                action = drone.fly();
+               }
+               else {//The direction must be NORTH or SOUTH
+                    if (currentDirection == Direction.SOUTH){
+                        action = drone.head(currentDirection.right());
+                    }
+                    else {
+                        action = drone.head(currentDirection.left())
+                    }
+                }
 
-
-
-   
-       action = drone.fly();
+        }
 
        return action;
     }

--- a/src/main/java/ca/mcmaster/se2aa4/island/teamXXX/algorithm/spiral/CenterState.java
+++ b/src/main/java/ca/mcmaster/se2aa4/island/teamXXX/algorithm/spiral/CenterState.java
@@ -2,47 +2,60 @@ package ca.mcmaster.se2aa4.island.teamXXX.algorithm.spiral;
 
 import ca.mcmaster.se2aa4.island.teamXXX.actions.Action;
 import ca.mcmaster.se2aa4.island.teamXXX.algorithm.State;
+import ca.mcmaster.se2aa4.island.teamXXX.drone.Direction;
 import ca.mcmaster.se2aa4.island.teamXXX.drone.Drone;
-import ca.mcmaster.se2aa4.island.teamXXX.drone.Position;
 import ca.mcmaster.se2aa4.island.teamXXX.result.ActionResult;
 
 public class CenterState extends State {
-    private int mapWidth;
-    private int mapHeight;
+    private final int centerX;
+    private final int centerY;
+    private Action action;
 
-    public CenterState(Drone drone,int mapHeight,int mapWidth) {//Assume DimensionFindingState can transfer width and height as parameter
+    public CenterState(Drone drone, int mapHeight, int mapWidth) {
         super(drone);
-        this.mapHeight = mapHeight;
-        this.mapWidth = mapWidth;
+        this.centerX = (int) Math.ceil(mapWidth / 2.0);
+        this.centerY = (int) Math.ceil(mapHeight / 2.0);
     }
 
-    public boolean isCenter(Position position){
-        int centerX = (int) Math.ceil(mapWidth / 2);
-        int centerY = (int) Math.ceil(mapHeight / 2);
-        boolean is_center = (position.getX()== centerX && position.getY() == centerY);
-        return is_center;
+    public boolean isCenter() {
+        int currentX = getDrone().getPosition().getX();
+        int currentY = getDrone().getPosition().getY();
+        int deltaX = centerX - currentX;
+        int deltaY = centerY - currentY;
 
+        return Math.abs(deltaX) <= 1 && Math.abs(deltaY) <= 1;
     }
 
     @Override
-    public State nextState(ActionResult action) {
-        // If the state still has work to be done then it should go to the current state
-        // Otherwise it should go to the SpiralState
-        // TODO Auto-generated method stub
-        //throw new UnsupportedOperationException("Unimplemented method 'nextState'");
-
-        if (isCenter(getDrone().getPosition())) {
-            return new SpiralState(getDrone());
-        }
-
-        return this;//if not center, stay at current state
+    public State nextState(ActionResult result) {
+        Drone drone = getDrone();
+        drone.expend(result.getCost());
+        action.consume(drone, result);
+        return isCenter() ? new SpiralState(getDrone()) : this;
     }
-
 
     @Override
     public Action getAction() {
-        // TODO Auto-generated method stub
-        throw new UnsupportedOperationException("Unimplemented method 'getAction'");
-    }
+        Drone drone = getDrone();
+        int currentX = drone.getPosition().getX();
+        int currentY = drone.getPosition().getY();
 
+        int deltaX = centerX - currentX;
+        int deltaY = centerY - currentY;
+        
+        Direction currentDirection = drone.getDirection();
+
+        if (isCenter()) {
+            return null; 
+        }
+
+
+
+
+
+   
+       action = drone.fly();
+
+       return action;
+    }
 }

--- a/src/main/java/ca/mcmaster/se2aa4/island/teamXXX/algorithm/spiral/DimensionFindingState.java
+++ b/src/main/java/ca/mcmaster/se2aa4/island/teamXXX/algorithm/spiral/DimensionFindingState.java
@@ -7,8 +7,11 @@ import ca.mcmaster.se2aa4.island.teamXXX.result.ActionResult;
 
 public class DimensionFindingState extends State {
 
-    public DimensionFindingState(Drone drone) {
+
+
+    public DimensionFindingState(Drone drone, int mapWidth, int mapHeight) {
         super(drone);
+
     }
 
     @Override

--- a/src/main/java/ca/mcmaster/se2aa4/island/teamXXX/algorithm/spiral/SpiralSearchDroneAlgorithm.java
+++ b/src/main/java/ca/mcmaster/se2aa4/island/teamXXX/algorithm/spiral/SpiralSearchDroneAlgorithm.java
@@ -10,6 +10,9 @@ public class SpiralSearchDroneAlgorithm extends DroneAlgorithm {
         super(drone);
     }
 
+
+
+
     @Override
     protected State getStartState(Drone drone) {
         return new StartState(drone);


### PR DESCRIPTION
### Pull Request Description:
This PR completes the implementation of the `CenterState` logic, allowing the drone to fly toward the center of the map after the `Dimension Finding State`. The main logic involves:

- **Heading Adjustment**: The drone continuously adjusts its heading along the X and Y axes toward the center using `head` commands.
- **Flying to the Center**: Once the drone is close to the center's X axis or Y axis, it switches to using `fly` commands to move directly to the center.
- **Error Margin**: The error margin is approximately 2 units due to the drone moving 3 units per flight. I haven’t found a way to control this error within 1 unit for now.
- **Direction Adjustments**: When the drone is within 1-2 units of the X or Y axis, it enters the next phase to adjust its heading to ensure it flies directly toward the center.

### Key Changes:
- The `CenterState` now ensures the drone flies towards the center of the map by adjusting the heading along the X and Y axes.
- Uses `if-else` statements to handle the logic, though the approach may appear somewhat bulky.
- When the drone is within 1-2 units of the center, its heading is adjusted to ensure it faces the correct direction for the final flight towards the center.

### Known Issues:
- **Error Margin**: The drone's position remains off by up to 2 units due to the 3-unit flying step.
- **Heading Adjustments**: The `if-else` logic is inefficient, but it currently represents the best solution I could think of.

### Testing:
- The test cases for `CenterState` are still to be written. The issues regarding test cases for this state are covered in **Issue #41**, which also includes the creation of the `CenterState`. Could I just close #41 and make a new issue for test cases?

